### PR TITLE
Add the correct modid to the recipe type name.

### DIFF
--- a/src/main/java/mythicbotany/ModRecipes.java
+++ b/src/main/java/mythicbotany/ModRecipes.java
@@ -8,8 +8,8 @@ import net.minecraft.item.crafting.IRecipeType;
 
 public class ModRecipes {
 
-    public static final IRecipeType<IInfuserRecipe> INFUSER = IRecipeType.register("infusion");
-    public static final IRecipeType<RuneRitualRecipe> RUNE_RITUAL = IRecipeType.register("rune_ritual");
+    public static final IRecipeType<IInfuserRecipe> INFUSER = IRecipeType.register(MythicBotany.getInstance().modid + ":infusion");
+    public static final IRecipeType<RuneRitualRecipe> RUNE_RITUAL = IRecipeType.register(MythicBotany.getInstance().modid + ":rune_ritual");
 
     public static final IRecipeSerializer<InfuserRecipe> INFUSER_SERIALIZER = new InfuserRecipe.Serializer();
     public static final IRecipeSerializer<RuneRitualRecipe> RUNE_RITUAL_SERIALIZER = new RuneRitualRecipe.Serializer();


### PR DESCRIPTION
The string you pass in gets turned into a ResourceLocation, so it ends up being `minecraft:infusion` and `minecraft:rune_ritual`

This PR makes it: `mythicbotany:infusion` and `mythicbotany:rune_ritual`