### PR TITLE
Quick fix for Botania 1.18.2 433

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     coremods 'io.github.noeppi_noeppi.misc:CoreModTypes:5.0.2-1'
     
     implementation fg.deobf('io.github.noeppi_noeppi.mods:LibX:1.18.2-3.2.15')
-    implementation fg.deobf('vazkii.botania:Botania:1.18.2-431')
+    implementation fg.deobf('vazkii.botania:Botania:1.18.2-433')
     implementation fg.deobf('vazkii.patchouli:Patchouli:1.18.2-67')
     implementation fg.deobf('top.theillusivec4.curios:curios-forge:1.18.2-5.0.6.3')
 

--- a/src/main/java/mythicbotany/ModItems.java
+++ b/src/main/java/mythicbotany/ModItems.java
@@ -46,7 +46,7 @@ public class ModItems {
     public static final Item manaRingGreatest = new GreatestManaRing(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1).fireResistant());
     public static final Item auraRingGreatest = new GreatestAuraRing(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1).fireResistant());
     public static final Item fadedNetherStar = new ItemFadedNetherStar();
-    public static final Item dreamwoodTwigWand = new ItemDreamwoodWand(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1).rarity(Rarity.RARE));
+    //public static final Item dreamwoodTwigWand = new ItemDreamwoodWand(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1).rarity(Rarity.RARE));
     public static final Item fireRing = new ItemFireRing(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1));
     public static final Item iceRing = new ItemIceRing(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1));
     public static final Item gjallarHornEmpty = new ItemBase(MythicBotany.getInstance(), new Properties().stacksTo(1));

--- a/src/main/java/mythicbotany/ModItems.java
+++ b/src/main/java/mythicbotany/ModItems.java
@@ -46,7 +46,7 @@ public class ModItems {
     public static final Item manaRingGreatest = new GreatestManaRing(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1).fireResistant());
     public static final Item auraRingGreatest = new GreatestAuraRing(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1).fireResistant());
     public static final Item fadedNetherStar = new ItemFadedNetherStar();
-    //public static final Item dreamwoodTwigWand = new ItemDreamwoodWand(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1).rarity(Rarity.RARE));
+    public static final Item dreamwoodTwigWand = new ItemDreamwoodWand(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1).rarity(Rarity.RARE));
     public static final Item fireRing = new ItemFireRing(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1));
     public static final Item iceRing = new ItemIceRing(new Properties().tab(MythicBotany.getInstance().tab).stacksTo(1));
     public static final Item gjallarHornEmpty = new ItemBase(MythicBotany.getInstance(), new Properties().stacksTo(1));

--- a/src/main/java/mythicbotany/data/recipes/RecipeProvider.java
+++ b/src/main/java/mythicbotany/data/recipes/RecipeProvider.java
@@ -42,7 +42,7 @@ public class RecipeProvider extends RecipeProviderBase implements CraftingExtens
     @Override
     protected void setup() {
         this.makeFloatingFlowerRecipes();
-        this.makeDreamwoodWandRecipe();
+        //this.makeDreamwoodWandRecipe();
 
         this.doubleCompress(ModItems.alfsteelNugget, ModItems.alfsteelIngot, ModBlocks.alfsteelBlock, true);
         this.shaped(ModItems.fireRing, "re ", "e e", " e ", 'r', ModItems.muspelheimRune, 'e', ModTags.Items.INGOTS_ELEMENTIUM);

--- a/src/main/java/mythicbotany/wand/ItemDreamwoodWand.java
+++ b/src/main/java/mythicbotany/wand/ItemDreamwoodWand.java
@@ -53,7 +53,7 @@ import java.util.function.Consumer;
 public class ItemDreamwoodWand extends ItemTwigWand implements Registerable {
 
     public ItemDreamwoodWand(Properties builder) {
-        super(builder);
+        super(ChatFormatting.LIGHT_PURPLE, builder);
         MinecraftForge.EVENT_BUS.addListener(this::onEntityInteract);
     }
 

--- a/src/main/java/mythicbotany/wand/ItemDreamwoodWand.java
+++ b/src/main/java/mythicbotany/wand/ItemDreamwoodWand.java
@@ -6,6 +6,7 @@ import io.github.noeppi_noeppi.libx.mod.registration.Registerable;
 import io.github.noeppi_noeppi.libx.render.RenderHelper;
 import mythicbotany.ModItems;
 import mythicbotany.MythicBotany;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.item.ItemProperties;
 import net.minecraft.core.BlockPos;

--- a/src/main/java/mythicbotany/wand/RecipeDreamwoodWand.java
+++ b/src/main/java/mythicbotany/wand/RecipeDreamwoodWand.java
@@ -43,12 +43,12 @@ public class RecipeDreamwoodWand extends TwigWandRecipe {
                 colorId = ((BlockModMushroom)((BlockItem)item).getBlock()).color.getId();
             }
             if (first != -1) {
-                return ItemDreamwoodWand.forColors(first, colorId);
+                return ItemDreamwoodWand.setColors(getResultItem().copy(), first, colorId);
             }
             first = colorId;
         }
 
-        return ItemTwigWand.forColors(first != -1 ? first : 0, 0);
+        return ItemTwigWand.setColors(getResultItem().copy(), first != -1 ? first : 0, 0);
     }
 
     @Nonnull


### PR DESCRIPTION
- Disable Dreamwood Wand item and recipe registration

Resolves #108 